### PR TITLE
Modify integration guideline headers

### DIFF
--- a/docs/operating-systems/learning-community.md
+++ b/docs/operating-systems/learning-community.md
@@ -73,6 +73,15 @@ forum that best connects to your situation, as illustrated with these examples.
 ## Integration Guidelines
 
 ### Commit Messages
+- Commit messages should follow the rules described by the [Conventional
+  Commits Standard](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+  Here is an example:
+
+    ```
+    fix: Add the correct percentages to grading table in syllabus
+    ```
+    
+ ### Pull Requests (PR)
 - To ensure the creation of uniform pull requests (PR), you should follow these
   syntactic rules:
 
@@ -82,14 +91,6 @@ forum that best connects to your situation, as illustrated with these examples.
     - The description should be meaningful and concise (less than 50
       characters).
 
-- Commit messages should follow the rules described by the [Conventional
-  Commits Standard](https://www.conventionalcommits.org/en/v1.0.0/#summary).
-  Here is an example:
-
-    ```
-    fix: Add the correct percentages to grading table in syllabus
-    ```
-### Pull Requests (PR)
 - So as to avoid unnecessary builds on Netlify, excessive pushes to pull
   requests should be avoided if possible. In order to preview your changes to
   the web site, please adopt the following process that requires


### PR DESCRIPTION
Integration guideline headers and information underneath was moved to make more sense.