### PR TITLE
Enhancing documentation of Windows / Mac installation of course tools

### DIFF
--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -208,11 +208,11 @@ You want your output to say you have the clang version.
 - Navigate to https://docs.docker.com/desktop/install/windows-install/, get the installer, and follow the instructions.
 
 ### Python 3.10
-1. Go to the Microsoft Store app, and install 
+Go to the Microsoft Store app, and install: 
   ```Python 3.10```
-2. Use
+Check version:
   ```python --version``` 
-  to check version.
+ 
 
 ### Golang
 1. Download Go from the official website (https://go.dev/dl/).
@@ -223,14 +223,16 @@ You want your output to say you have the clang version.
 
 ### pipx / poetry / gatorgrade
 
-1. install pipx: 
+Install pipx: 
   ```python3 -m pip install --user pipx``` 
   and then 
-  ```python3 -m pipx ensurepath```.
+  ```python3 -m pipx ensurepath```
 
-2. you can then install gatorgrade using pipx using the command ```pipx install gatorgrade```.
+Install Gatorgrade using pipx:
+  ```pipx install gatorgrade```
 
-3. Use the ```curl -sSL https://install.python-poetry.org | python3 -``` command to install poetry.
+Command to install poetry.
+  ```curl -sSL https://install.python-poetry.org | python3 -``` 
 
 ## Locally installing the required tools for Linux
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -163,7 +163,7 @@ If you choose the right version and it still isn't working, follow these instruc
 
 ### GCC installation process:
 
-GCC might already be installed on your computer since you have a mac. To check type:
+GCC might already be installed on your computer since you have a MAC. To check type:
 
 `gcc –version`
 
@@ -171,24 +171,26 @@ Your output should specify you have the clang version.
 
 ## Locally installing the required tools for Windows
 
-### gcc & ```make``` command
+### GCC & ```make``` command
 
 1. Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
 2. Search for the MSYS2 MinGW x64 environment and open it.
 3. Use  ```pacman -Syuu``` command to update the environment.
 4. Use  ```pacman -S mingw-w64-x86_64-toolchain``` command to install the toolchain, which contains GCC and Make command.
 5. Verify the installation by entering ```gcc —version``` inside the terminal. It should return the version of GCC you installed.
-6. In order to use the gcc toolchain, you have to add this to your path environment variable: <MSYS2 location>/mingw64/bin .
+6. In order to use the GCC toolchain, you have to add this to your path environment variable: <MSYS2 location>/mingw64/bin .
 7. You can also change the name of make from mingw32-make to make to make it easier to execute in the terminal.
 8. In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
-    1. Hello.c should contain:
+  
+     Hello.c should contain:
       ``` #include <stdio.h>
  
       int main() {
           printf("Hello, world!\n");
           return 0;
       }```
-    2. Makefile should contain:
+  
+    Makefile should contain:
       ``` all: hello.exe
 
       hello.exe: hello.o
@@ -199,6 +201,7 @@ Your output should specify you have the clang version.
           
       clean:
           rm hello.o hello.exe```
+  
 9. Navigate to the directory in your terminal, enter make and see the program run!
 
 ### Docker

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -148,19 +148,25 @@ If you haven't installed Go: [the instructions](https://go.dev/dl/)
 Make sure you click the right chip that your laptop has.
 
 If you choose the right version and it still isn't working, follow these instructions:
-- Type in the command into your terminal: 
+
+Type in the command into your terminal: 
 ```
 nano ~/.zshrc
 ``` 
-  - Add in the following 2 paths into the file that pops up in your terminal:
-    - ```export PATH=$PATH:/usr/local/go/bin```
-    - ```export PATH=$PATH:$GOPATH/bin```
-- After you save the changes in that file, source the file using the command:
+Add in the following 2 paths into the file that pops up in your terminal:
+```
+export PATH=$PATH:/usr/local/go/bin
+```
+
+```
+export PATH=$PATH:$GOPATH/bin
+```
+After you save the changes in that file, source the file using the command:
 ```
 . ~/.zshrc
 ```
-- Check if Go is now working using the ```go version``` command.
 
+Check if Go is now working using the ```go version``` command.
 
 ### GCC installation process:
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -167,7 +167,6 @@ Your output should specify you have the clang version.
 ## Locally installing the required tools for Windows
 
 ### GCC & `make` command
-
 - Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
 - Search for the MSYS2 MinGW x64 environment and open it.
 - Use  `pacman -Syuu` command to update the environment.
@@ -204,11 +203,9 @@ Your output should specify you have the clang version.
 Navigate to the directory in your terminal, and run the make command.
 
 ### Docker
-  
 Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
 
 ### Python 3.10
-  
 Go to the Microsoft Store app to install: 
 ```
 Python 3.10
@@ -222,7 +219,6 @@ python --version
  
 
 ### Golang
-  
 - Download Go from the official website (https://go.dev/dl/).
 - Follow the installer's instructions.
 - Search for ```env``` on your computer and open environment variables.
@@ -277,22 +273,18 @@ $ pipx install gatorgrade
 ```
 
 ### Poetry
-
 [Poetry](https://python-poetry.org/docs/) can be downloaded by the commands below.  On some systems, python may still refer to Python 2 instead of Python 3. Better python3 binary to avoid ambiguity.
 ```
 curl -sSL https://install.python-poetry.org | python3 -
 ```
-### Docker
-  
+### Docker 
 Install [Docker](https://docs.docker.com/engine/install/ubuntu/):
 ```
 $ sudo apt-get update
 $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
 ### C and GCC:
- 
 C and GCC should be installed by default in Linux distributors.
 
 ### Go
-  
 In order to download [Go](https://go.dev/doc/install) on Linux click this [link](https://go.dev/dl/) and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download.

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -148,16 +148,17 @@ If you haven't installed Go: [the instructions](https://go.dev/dl/)
 Make sure you click the right chip that your laptop has.
 
 If you choose the right version and it still isn't working, follow these instructions:
-- Type in the command: 
+- Type in the command into your terminal: 
 ```
 nano ~/.zshrc
 ``` 
-into your terminal
-- Add in the following 2 paths into the file that pops up in your terminal:
-  - ```export PATH=$PATH:/usr/local/go/bin```
-  - ```export PATH=$PATH:$GOPATH/bin```
-- After you save the changes in that file, source the file using the command ```
-. ~/.zshrc```.
+  - Add in the following 2 paths into the file that pops up in your terminal:
+    - ```export PATH=$PATH:/usr/local/go/bin```
+    - ```export PATH=$PATH:$GOPATH/bin```
+- After you save the changes in that file, source the file using the command:
+```
+. ~/.zshrc
+```
 - Check if Go is now working using the ```go version``` command.
 
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -208,8 +208,11 @@ You want your output to say you have the clang version.
 - Navigate to https://docs.docker.com/desktop/install/windows-install/, get the installer, and follow the instructions.
 
 ### Python 3.10
-1. Go to the Microsoft Store app, search ```Python 3.10``` and install.
-2. Can check this worked by using the ```python --version``` command.
+1. Go to the Microsoft Store app, and install 
+  ```Python 3.10```
+2. Use
+  ```python --version``` 
+  to check version.
 
 ### Golang
 1. Download Go from the official website (https://go.dev/dl/).
@@ -220,7 +223,10 @@ You want your output to say you have the clang version.
 
 ### pipx / poetry / gatorgrade
 
-1. install pipx using the command ```python3 -m pip install --user pipx``` and then ```python3 -m pipx ensurepath```.
+1. install pipx: 
+  ```python3 -m pip install --user pipx``` 
+  and then 
+  ```python3 -m pipx ensurepath```.
 
 2. you can then install gatorgrade using pipx using the command ```pipx install gatorgrade```.
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -87,7 +87,7 @@ Go to your terminal and type
 
 `python –version`
 
-If the output says python 3.10 you are all set.
+If the output says `Python 3.10` you are all set.
 
 If the output says you have a different version type this command:
 
@@ -167,10 +167,7 @@ GCC might already be installed on your computer since you have a mac. To check t
 
 `gcc –version`
 
-You want your output to say you have the clang version.
-
-
-
+Your output should specify you have the clang version.
 
 ## Locally installing the required tools for Windows
 
@@ -205,7 +202,7 @@ You want your output to say you have the clang version.
 9. Navigate to the directory in your terminal, enter make and see the program run!
 
 ### Docker
-- Navigate to https://docs.docker.com/desktop/install/windows-install/, get the installer, and follow the instructions.
+- Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker, and follow the instructions.
 
 ### Python 3.10
 Go to the Microsoft Store app, and install: 
@@ -221,18 +218,26 @@ Check version:
 4. Copy the path for Go and paste it into your user variable editing window.
 5. Test that go is working by typing ```go version``` into your terminal.
 
-### pipx / poetry / gatorgrade
+### Pipx / Poetry / Gatorgrade
 
 Install pipx: 
-  ```python3 -m pip install --user pipx``` 
+  ```
+  python3 -m pip install --user pipx
+  ``` 
   and then 
-  ```python3 -m pipx ensurepath```
+  ```
+  python3 -m pipx ensurepath
+  ```
 
 Install Gatorgrade using pipx:
-  ```pipx install gatorgrade```
+  ```
+  pipx install gatorgrade
+  ```
 
 Command to install poetry.
-  ```curl -sSL https://install.python-poetry.org | python3 -``` 
+  ```
+  curl -sSL https://install.python-poetry.org | python3 -
+  ``` 
 
 ## Locally installing the required tools for Linux
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -89,8 +89,6 @@ Go to your terminal and type
 
 If the output says `Python 3.10` you are all set.
 
-If the output says you have a different version type this command:
-
 You should go to [this website](https://www.python.org/downloads/) and download the mac version. 
 
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -96,11 +96,9 @@ You should go to [this website](https://www.python.org/downloads/) and download 
 
 Using Homebrew, pipx can be installed with:
 
-
 `brew install pipx`
 
 The path can be ensured with:
-
 
 `pipx ensurepath`
 
@@ -117,7 +115,6 @@ The version can be verified with:
 `pipx --version`
 
 ### Poetry installation process:
-
 
 In your terminal window type:
 
@@ -137,7 +134,7 @@ Once poetry is installed then retype
 
 `poetry –version`
 
-### GatorGrade installation process:
+### Gatorgrade installation process:
 
 If you haven’t installed gatorgrade type this command:
 
@@ -161,7 +158,7 @@ If you choose the right version and it still isn't working, follow these instruc
 
 ### GCC installation process:
 
-GCC might already be installed on your computer since you have a MAC. To check type:
+GCC might already be installed on your computer since you have a Mac. To check type:
 
 `gcc –version`
 
@@ -207,9 +204,11 @@ Your output should specify you have the clang version.
 Navigate to the directory in your terminal, and run the make command.
 
 ### Docker
+  
 Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
 
 ### Python 3.10
+  
 Go to the Microsoft Store app to install: 
 ```
 Python 3.10
@@ -223,6 +222,7 @@ python --version
  
 
 ### Golang
+  
 - Download Go from the official website (https://go.dev/dl/).
 - Follow the installer's instructions.
 - Search for ```env``` on your computer and open environment variables.
@@ -261,6 +261,7 @@ sudo apt install python3.10
 ```
 
 ### [Pipx](https://pypa.github.io/pipx/installation/)
+  
 Install Pipx with commands below:
 ```
 $ python3 -m pip install --user pipx
@@ -268,6 +269,7 @@ $ python3 -m pipx ensurepath
 ```
 
 ### Gatorgrade
+  
 After installing pipx, you are ready to install another tool called [Gatorgrade](https://github.com/GatorEducator/gatorgrade) by using pipx
 Install Gatorgrade by:
 ```
@@ -281,14 +283,16 @@ $ pipx install gatorgrade
 curl -sSL https://install.python-poetry.org | python3 -
 ```
 ### Docker
+  
 Install [Docker](https://docs.docker.com/engine/install/ubuntu/):
 ```
 $ sudo apt-get update
 $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
-### C and gcc:
+### C and GCC:
  
-C and gcc should be installed by default in Linux distributors.
+C and GCC should be installed by default in Linux distributors.
 
 ### Go
+  
 In order to download [Go](https://go.dev/doc/install) on Linux click this [link](https://go.dev/dl/) and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download.

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -148,13 +148,13 @@ If you haven’t installed gatorgrade type this command:
 
 ### Go installation process:
 
-If you haven't installed go click the link and follow [the instructions](https://go.dev/dl/)
+If you haven't installed Go click the link and follow [the instructions](https://go.dev/dl/)
 
 Make sure you click the right chip that your laptop has.
 
 If you choose the right version and it still isn't working, follow these instructions:
-1. type in the command ```nano ~/.zshrc``` into your terminal
-2. add in the following 2 paths into the file that pops up in your terminal:
+1. Type in the command ```nano ~/.zshrc``` into your terminal
+2. Add in the following 2 paths into the file that pops up in your terminal:
   - ```export PATH=$PATH:/usr/local/go/bin```
   - ```export PATH=$PATH:$GOPATH/bin```
 3. After you save the changes in that file, source the file using the command ```. ~/.zshrc```.
@@ -175,9 +175,9 @@ Your output should specify you have the clang version.
 
 1. Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
 2. Search for the MSYS2 MinGW x64 environment and open it.
-3. Write ```pacman -Syuu``` to update the environment.
-4. Write ```pacman -S mingw-w64-x86_64-toolchain``` to install the toolchain, which contains gcc and the make command.
-5. Verify the installation worked by entering ```gcc —version``` in your terminal. If it is working it should return the version of gcc you installed.
+3. Use  ```pacman -Syuu``` command to update the environment.
+4. Use  ```pacman -S mingw-w64-x86_64-toolchain``` command to install the toolchain, which contains GCC and Make command.
+5. Verify the installation by entering ```gcc —version``` inside the terminal. It should return the version of GCC you installed.
 6. In order to use the gcc toolchain, you have to add this to your path environment variable: <MSYS2 location>/mingw64/bin .
 7. You can also change the name of make from mingw32-make to make to make it easier to execute in the terminal.
 8. In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
@@ -213,10 +213,10 @@ Check version:
 
 ### Golang
 1. Download Go from the official website (https://go.dev/dl/).
-2. Follow the installer's instructions and wait while it is downloaded onto your laptop.
+2. Follow the installer's instructions.
 3. Search for ```env``` on your computer and open environment variables.
-4. Copy the path for Go and paste it into your user variable editing window.
-5. Test that go is working by typing ```go version``` into your terminal.
+4. Copy the path for Go and paste into your user variable editing window.
+5. Test Go is installed by typing ```go version``` into your terminal.
 
 ### Pipx / Poetry / Gatorgrade
 

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -148,17 +148,17 @@ If you haven’t installed gatorgrade type this command:
 
 ### Go installation process:
 
-If you haven't installed Go click the link and follow [the instructions](https://go.dev/dl/)
+If you haven't installed Go: [the instructions](https://go.dev/dl/)
 
 Make sure you click the right chip that your laptop has.
 
 If you choose the right version and it still isn't working, follow these instructions:
-1. Type in the command ```nano ~/.zshrc``` into your terminal
-2. Add in the following 2 paths into the file that pops up in your terminal:
+- Type in the command ```nano ~/.zshrc``` into your terminal
+- Add in the following 2 paths into the file that pops up in your terminal:
   - ```export PATH=$PATH:/usr/local/go/bin```
   - ```export PATH=$PATH:$GOPATH/bin```
-3. After you save the changes in that file, source the file using the command ```. ~/.zshrc```.
-4. Check if go is now working using the ```go version``` command.
+- After you save the changes in that file, source the file using the command ```. ~/.zshrc```.
+- heck if go is now working using the ```go version``` command.
 
 
 ### GCC installation process:
@@ -171,18 +171,18 @@ Your output should specify you have the clang version.
 
 ## Locally installing the required tools for Windows
 
-### GCC & ```make``` command
+### GCC & `make` command
 
 1. Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
 2. Search for the MSYS2 MinGW x64 environment and open it.
-3. Use  ```pacman -Syuu``` command to update the environment.
-4. Use  ```pacman -S mingw-w64-x86_64-toolchain``` command to install the toolchain, which contains GCC and Make command.
-5. Verify the installation by entering ```gcc —version``` inside the terminal. It should return the version of GCC you installed.
+3. Use  `pacman -Syuu` command to update the environment.
+4. Use  `pacman -S mingw-w64-x86_64-toolchain` command to install the toolchain, which contains GCC and Make command.
+5. Verify the installation by entering `gcc —version` inside the terminal. It should return the version of GCC you installed.
 6. In order to use the GCC toolchain, you have to add to the path environment variable: <MSYS2 location>/mingw64/bin .
 7. You can also change the name of make from mingw32-make to make so it is easier to execute in the terminal.
 8. In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
   
-     Hello.c should contain:
+     Contents of Hello.c:
       ``` #include <stdio.h>
  
       int main() {
@@ -190,7 +190,7 @@ Your output should specify you have the clang version.
           return 0;
       }```
   
-    Makefile should contain:
+    Contents of Makefile:
       ``` all: hello.exe
 
       hello.exe: hello.o
@@ -201,17 +201,19 @@ Your output should specify you have the clang version.
           
       clean:
           rm hello.o hello.exe```
-  
+ 
 9. Navigate to the directory in your terminal, enter make and see the program run!
 
 ### Docker
-- Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker, and follow the instructions.
+Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
 
 ### Python 3.10
-Go to the Microsoft Store app, and install: 
-  ```Python 3.10```
+Go to the Microsoft Store app to install: 
+```Python 3.10```
+
+
 Check version:
-  ```python --version``` 
+```python --version``` 
  
 
 ### Golang
@@ -283,4 +285,4 @@ $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plug
 C and gcc should be installed by default in Linux distributors
 
 ### Go
-In order to download [Go](https://go.dev/doc/install) on Linux click this link https://go.dev/dl/  and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download
+In order to download [Go](https://go.dev/doc/install) on Linux click this link https://go.dev/dl/  and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download.

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -173,25 +173,28 @@ Your output should specify you have the clang version.
 
 ### GCC & `make` command
 
-1. Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
-2. Search for the MSYS2 MinGW x64 environment and open it.
-3. Use  `pacman -Syuu` command to update the environment.
-4. Use  `pacman -S mingw-w64-x86_64-toolchain` command to install the toolchain, which contains GCC and Make command.
-5. Verify the installation by entering `gcc —version` inside the terminal. It should return the version of GCC you installed.
-6. In order to use the GCC toolchain, you have to add to the path environment variable: <MSYS2 location>/mingw64/bin .
-7. You can also change the name of make from mingw32-make to make so it is easier to execute in the terminal.
-8. In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
+- Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
+- Search for the MSYS2 MinGW x64 environment and open it.
+- Use  `pacman -Syuu` command to update the environment.
+- Use  `pacman -S mingw-w64-x86_64-toolchain` command to install the toolchain, which contains GCC and Make command.
+- Verify the installation by entering `gcc —version` inside the terminal. It should return the version of GCC you installed.
+- In order to use the GCC toolchain, you have to add to the path environment variable: <MSYS2 location>/mingw64/bin .
+- You can also change the name of make from mingw32-make to make so it is easier to execute in the terminal.
+- In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
   
      Contents of Hello.c:
-      ``` #include <stdio.h>
+      ``` 
+      #include <stdio.h>
  
       int main() {
           printf("Hello, world!\n");
           return 0;
-      }```
+      }
+      ```
   
     Contents of Makefile:
-      ``` all: hello.exe
+      ``` 
+      all: hello.exe
 
       hello.exe: hello.o
           gcc -o hello.exe hello.o
@@ -200,9 +203,10 @@ Your output should specify you have the clang version.
           gcc -c hello.c
           
       clean:
-          rm hello.o hello.exe```
+          rm hello.o hello.exe
+      ```
  
-9. Navigate to the directory in your terminal, enter make and see the program run!
+- Navigate to the directory in your terminal, and run the make command.
 
 ### Docker
 Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
@@ -217,11 +221,11 @@ Check version:
  
 
 ### Golang
-1. Download Go from the official website (https://go.dev/dl/).
-2. Follow the installer's instructions.
-3. Search for ```env``` on your computer and open environment variables.
-4. Copy the path for Go and paste into your user variable editing window.
-5. Test Go is installed by typing ```go version``` into your terminal.
+- Download Go from the official website (https://go.dev/dl/).
+- Follow the installer's instructions.
+- Search for ```env``` on your computer and open environment variables.
+- Copy the path for Go and paste into your user variable editing window.
+- Test Go is installed by typing ```go version``` into your terminal.
 
 ### Pipx / Poetry / Gatorgrade
 
@@ -282,7 +286,7 @@ $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plug
 ```
 ### C and gcc:
  
-C and gcc should be installed by default in Linux distributors
+C and gcc should be installed by default in Linux distributors.
 
 ### Go
-In order to download [Go](https://go.dev/doc/install) on Linux click this link https://go.dev/dl/  and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download.
+In order to download [Go](https://go.dev/doc/install) on Linux click this [link](https://go.dev/dl/) and click the LINUX button that is underneath the feature downloads header. Once that is downloaded follow the directions that it gives you in order to complete the download.

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -178,8 +178,8 @@ Your output should specify you have the clang version.
 3. Use  ```pacman -Syuu``` command to update the environment.
 4. Use  ```pacman -S mingw-w64-x86_64-toolchain``` command to install the toolchain, which contains GCC and Make command.
 5. Verify the installation by entering ```gcc —version``` inside the terminal. It should return the version of GCC you installed.
-6. In order to use the GCC toolchain, you have to add this to your path environment variable: <MSYS2 location>/mingw64/bin .
-7. You can also change the name of make from mingw32-make to make to make it easier to execute in the terminal.
+6. In order to use the GCC toolchain, you have to add to the path environment variable: <MSYS2 location>/mingw64/bin .
+7. You can also change the name of make from mingw32-make to make so it is easier to execute in the terminal.
 8. In order to test everything went correctly, create two new files in a directory named hello.c and makefile.
   
      Hello.c should contain:

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -137,7 +137,7 @@ Once poetry is installed then retype
 
 `poetry –version`
 
-### Gatorade installation process:
+### GatorGrade installation process:
 
 If you haven’t installed gatorgrade type this command:
 
@@ -204,18 +204,22 @@ Your output should specify you have the clang version.
           rm hello.o hello.exe
       ```
  
-- Navigate to the directory in your terminal, and run the make command.
+Navigate to the directory in your terminal, and run the make command.
 
 ### Docker
 Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
 
 ### Python 3.10
 Go to the Microsoft Store app to install: 
-```Python 3.10```
+```
+Python 3.10
+```
 
 
 Check version:
-```python --version``` 
+```
+python --version
+``` 
  
 
 ### Golang

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -237,7 +237,7 @@ Install Gatorgrade using pipx:
   pipx install gatorgrade
   ```
 
-Command to install poetry.
+Command to install poetry:
   ```
   curl -sSL https://install.python-poetry.org | python3 -
   ``` 
@@ -246,7 +246,7 @@ Command to install poetry.
 
 ### Python3.10 or above
 
-[Python 3.10](https://computingforgeeks.com/how-to-install-python-on-ubuntu-linux-system/)  or above is expected. Please copy the commands below to download Python 3.10. Feel free to download the newest version if possible
+[Python 3.10](https://computingforgeeks.com/how-to-install-python-on-ubuntu-linux-system/)  or above is expected. Downlad Python with this command: 
 
 ```
 sudo apt install python3.10

--- a/docs/operating-systems/course-tools.md
+++ b/docs/operating-systems/course-tools.md
@@ -148,26 +148,31 @@ If you haven't installed Go: [the instructions](https://go.dev/dl/)
 Make sure you click the right chip that your laptop has.
 
 If you choose the right version and it still isn't working, follow these instructions:
-- Type in the command ```nano ~/.zshrc``` into your terminal
+- Type in the command: 
+```
+nano ~/.zshrc
+``` 
+into your terminal
 - Add in the following 2 paths into the file that pops up in your terminal:
   - ```export PATH=$PATH:/usr/local/go/bin```
   - ```export PATH=$PATH:$GOPATH/bin```
-- After you save the changes in that file, source the file using the command ```. ~/.zshrc```.
-- heck if go is now working using the ```go version``` command.
+- After you save the changes in that file, source the file using the command ```
+. ~/.zshrc```.
+- Check if Go is now working using the ```go version``` command.
 
 
 ### GCC installation process:
 
 GCC might already be installed on your computer since you have a Mac. To check type:
 
-`gcc –version`
+`gcc -–version`
 
 Your output should specify you have the clang version.
 
 ## Locally installing the required tools for Windows
 
 ### GCC & `make` command
-- Do not install MinGW directly, go to https://www.msys2.org/ and download MSYS2.
+- Do not install MinGW directly, go to this [website](https://www.msys2.org/) and download MSYS2.
 - Search for the MSYS2 MinGW x64 environment and open it.
 - Use  `pacman -Syuu` command to update the environment.
 - Use  `pacman -S mingw-w64-x86_64-toolchain` command to install the toolchain, which contains GCC and Make command.
@@ -203,7 +208,7 @@ Your output should specify you have the clang version.
 Navigate to the directory in your terminal, and run the make command.
 
 ### Docker
-Navigate to https://docs.docker.com/desktop/install/windows-install/ to install Docker.
+Navigate to this [website](https://docs.docker.com/desktop/install/windows-install/) to install Docker.
 
 ### Python 3.10
 Go to the Microsoft Store app to install: 
@@ -219,7 +224,7 @@ python --version
  
 
 ### Golang
-- Download Go from the official website (https://go.dev/dl/).
+- Download Go from the official [website](https://go.dev/dl/).
 - Follow the installer's instructions.
 - Search for ```env``` on your computer and open environment variables.
 - Copy the path for Go and paste into your user variable editing window.


### PR DESCRIPTION
I was able to replicate how Linux installation steps were written to the Windows and Mac installation steps, so these steps are easier to read. This also makes all the Operating Systems look similar, but also allows the users to see how different they are when it comes to installation steps 